### PR TITLE
Update maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,6 +53,6 @@ jobs:
           # login to GitHub Container Registry
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
           # build image
-          docker build . --tag ghcr.io/eclipse-opensmartclide/smartclide/tdinterest:$(date +'%Y-%m-%d')
+          docker build . --tag ghcr.io/eclipse-opensmartclide/smartclide/tdapi:$(date +'%Y-%m-%d')
           # push image
-          docker push ghcr.io/eclipse-opensmartclide/smartclide/tdinterest:$(date +'%Y-%m-%d')
+          docker push ghcr.io/eclipse-opensmartclide/smartclide/tdapi:$(date +'%Y-%m-%d')


### PR DESCRIPTION
[TD-Principal](https://github.com/eclipse-opensmartclide/smartclide-TD-Principal), [TD-Interest](https://github.com/eclipse-opensmartclide/smartclide-TD-Interest), [TD-Reusability-Index](https://github.com/eclipse-opensmartclide/smartclide-TD-Reusability-Index), have been merged in this repo.

The [TD-Principal](https://github.com/eclipse-opensmartclide/smartclide-TD-Principal), and [TD-Reusability-Index](https://github.com/eclipse-opensmartclide/smartclide-TD-Reusability-Index) can be archived, and the [TD-Interest](https://github.com/eclipse-opensmartclide/smartclide-TD-Interest) repo could be renamed to "smartclide-TD-API".

As for the deployment, the new docker image is "tdapi", and the following are no longer in need
- [tdprincipal](https://github.com/eclipse-opensmartclide/smartclide-TD-Principal/pkgs/container/smartclide%2Ftdprincipal)
- [tdreusability](https://github.com/orgs/eclipse-opensmartclide/packages/container/package/smartclide%2Ftdreusability)
- [tdinterest](https://github.com/orgs/eclipse-opensmartclide/packages/container/package/smartclide%2Ftdinterest)

This new image requires the SONARQUBE_URL env variable (that the tdprincipal images used) as well as all the necessary env variables that the tdinterest used for the database.